### PR TITLE
Add extra flexbox to fix supporter logos on smaller viewports

### DIFF
--- a/src/2025/styles/styles.css
+++ b/src/2025/styles/styles.css
@@ -444,7 +444,9 @@ ul#editions li svg {
     list-style: none;
     margin: 0;
     padding: 0;
-    display: inline;
+    display: flex; /* extra flexbox to center at smaller viewports */
+    flex-flow: row wrap;
+    justify-content: center;
 }
 
 #supporters h3 {


### PR DESCRIPTION
Before fix:

![current supporters list on smaller viewports - when a list has more than one logo, they stack vertically but left-aligned](https://github.com/user-attachments/assets/1224b366-cc32-4aa7-9a73-fc3487f0c10d)

With fix applied:

![fixed layout, with all supporter logos centered](https://github.com/user-attachments/assets/94c21999-6a4e-4e0b-9b09-0db9de56e65b)
